### PR TITLE
Fix assertion

### DIFF
--- a/src/ogt_vox.h
+++ b/src/ogt_vox.h
@@ -1902,7 +1902,7 @@
                 best_index = color_index;
             }
         }
-        assert(best_score < UINT32_MAX); // this might indicate a completely degenerate palette.
+        assert(best_score < INT32_MAX); // this might indicate a completely degenerate palette.
         return best_index;
     }
 


### PR DESCRIPTION
In `find_closest_color_in_palette` `best_score` is declared as int32_t. It's value is always `<UINT32_MAX` and assertion will always succeed(even in bad situations when `bad_score` is `INT32_MAX`). As I understand from code `best_score` should be compared to `INT32_MAX` not `UINT32_MAX`.