### PR TITLE
ogt_vox: fixed MATL chunk saving

### DIFF
--- a/src/ogt_vox.h
+++ b/src/ogt_vox.h
@@ -2074,7 +2074,7 @@
                 char matl_g[16] = "";
                 char matl_media[16] = "";
                 uint32_t matl_dict_size = 0;
-                uint32_t matl_dict_keyvalue_count = 0;
+                uint32_t matl_dict_keyvalue_count = 1;
 
                 if (matl.content_flags & k_ogt_vox_matl_have_metal) {
                     _vox_sprintf(matl_metal, sizeof(matl_metal), "%f", matl.metal);


### PR DESCRIPTION
the _type dict entry wasn't counted for the header of the dict