### PR TITLE
_vox_array::resize optimization - grow by at least 1.5x

### DIFF
--- a/src/ogt_vox.h
+++ b/src/ogt_vox.h
@@ -630,7 +630,12 @@
         }
         void resize(size_t new_count) {
             if (new_count > capacity)
-                reserve(new_count);
+            {
+                size_t new_capacity = capacity ? (capacity * 3) >> 1 : 2;   // grow by 50% each time, otherwise start at 2 elements.
+                new_capacity = new_count > new_capacity ? new_count : new_capacity; // ensure fits new_count
+                reserve(new_capacity);
+                assert(capacity >= new_count);
+            }
             count = new_count;
         }
         void push_back(const T & new_element) {


### PR DESCRIPTION
Discovered that during vox file loading resize was being called with ```count+1```, with capacity only being increased by 1 each time leading to very slow file reading for vox files with lots of models & instances - one file with many tens of thousands of such was taking over a half hour to load (I cancelled!), whereas after this optimization it took 18 seconds (including converting to my octree format in Avoyd).

This PR changes the resize to use the same approach you use elsewhere to avoid too many resizing calls.