### PR TITLE
ogt_vox: fix regression/bug with instance transforms not being correctly flattened when not importing groups

### DIFF
--- a/src/ogt_vox.h
+++ b/src/ogt_vox.h
@@ -1624,6 +1624,7 @@
                         flattened_transform = _vox_transform_multiply(flattened_transform, groups[group_index].transform);
                         group_index = groups[group_index].parent_group_index;
                     }
+                    instance->transform = flattened_transform;
                     instance->group_index = 0;
                 }
                 // add just a single parent group.


### PR DESCRIPTION
- flattened transform was being computed correctly, it just wasn't being assigned onto the output instance. 
- the net effect was that output instances were continuing using the group relative transform rather than the flattened transform.