### PR TITLE
Added asserts to catch saving and loading of a model with zero size

### DIFF
--- a/src/ogt_vox.h
+++ b/src/ogt_vox.h
@@ -1313,6 +1313,7 @@
                     _vox_file_read_uint32(fp, &size_x);
                     _vox_file_read_uint32(fp, &size_y);
                     _vox_file_read_uint32(fp, &size_z);
+                    ogt_assert(size_x && size_y && size_z, "SIZE chunk has zero size");
                     break;
                 }
                 case CHUNK_ID_XYZI:
@@ -2275,6 +2276,7 @@
             _vox_file_write_uint32(fp, 0);
 
             // write the SIZE chunk payload
+            ogt_assert(model->size_x && model->size_y && model->size_z, "model has zero size");
             _vox_file_write_uint32(fp, model->size_x);
             _vox_file_write_uint32(fp, model->size_y);
             _vox_file_write_uint32(fp, model->size_z);


### PR DESCRIPTION
Currently ogt_vox.h will assert on loading a model with 0 size when reading the `CHUNK_ID_XYZI` at line:

1320 `ogt_assert(size_x && size_y && size_z, "expected a SIZE chunk before XYZI chunk");`

https://github.com/jpaver/opengametools/blob/master/src/ogt_vox.h#L1320

This can be a little confusing, as the actual error can be due to the model having zero size. In addition I discovered this by saving out a .vox file with a model of zero size, so here I have also added an assert for this case in the write code.

Whilst MV appears to handle loading a 0 size model you can't create one using it's UI, so it's likely still good practice to assert on this.
