### PR TITLE
ogt_vox: added progress callback

### DIFF
--- a/src/ogt_vox.h
+++ b/src/ogt_vox.h
@@ -419,6 +419,13 @@
     void* ogt_vox_malloc(size_t size);
     void  ogt_vox_free(void* mem);
 
+    // progress feedback function with option to cancel a ogt_vox_write_scene operation. Percentage complete is approximately given by: 100.0f * progress.
+    typedef bool  (*ogt_vox_progress_callback_func)(float progress, void* user_data);
+
+    // set the progress callback function and user data to pass to it
+    void  ogt_vox_set_progress_callback_func(ogt_vox_progress_callback_func progress_callback_func, void* user_data);
+
+
     // flags for ogt_vox_read_scene_with_flags
     static const uint32_t k_read_scene_flags_groups                      = 1 << 0; // if not specified, all instance transforms will be flattened into world space. If specified, will read group information and keep all transforms as local transform relative to the group they are in.
     static const uint32_t k_read_scene_flags_keyframes                   = 1 << 1; // if specified, all instances and groups will contain keyframe data.
@@ -796,6 +803,17 @@
         size_t capacity;  // capacity of the array
         size_t count;      // size of the array
     };
+
+    // progress callback function.
+    static ogt_vox_progress_callback_func g_progress_callback_func = NULL;
+    static void* g_progress_callback_user_data = NULL;
+
+    // set the progress callback function.
+    void  ogt_vox_set_progress_callback_func(ogt_vox_progress_callback_func progress_callback_func, void* user_data)
+    {
+        g_progress_callback_func = progress_callback_func;
+        g_progress_callback_user_data = user_data;
+    }
 
     // matrix utilities
     static ogt_vox_transform _vox_transform_identity() {
@@ -1738,6 +1756,14 @@
                     break;
                 }
             } // end switch
+
+            if (g_progress_callback_func) {
+                // we indicate progress as 0.8f * amount of buffer read + 0.2f at end after processing 
+                if (!g_progress_callback_func(0.8f*(float)(fp->offset)/(float)(fp->buffer_size), g_progress_callback_user_data))
+                {
+                    return 0;
+                }
+            }
         }
 
         // ok, now that we've parsed all scene nodes - walk the scene hierarchy, and generate instances
@@ -2059,6 +2085,11 @@
             // copy the materials.
             scene->materials = materials;
         }
+
+        if (g_progress_callback_func) {
+            // we indicate progress as complete, but don't check for cancel as finished
+            g_progress_callback_func(1.0f, g_progress_callback_user_data);
+        }
         return scene;
     }
 
@@ -2298,6 +2329,15 @@
                             _vox_file_write_uint8(fp, color_index);
                         }
                     }
+                }
+            }
+
+            if (g_progress_callback_func) { 
+                // we indicate progress as number of models written, with an extra progress value for ending write
+                if (!g_progress_callback_func((float)(i + 1)/(float)(scene->num_models + 1), g_progress_callback_user_data))
+                {
+                    *buffer_size = 0;
+                    return NULL; // note: fp will be freed in dtor on exit
                 }
             }
         }
@@ -2594,6 +2634,11 @@
         {
             uint32_t* main_chunk_child_size = (uint32_t*)& buffer_data[offset_post_main_chunk - sizeof(uint32_t)];
             *main_chunk_child_size = *buffer_size - offset_post_main_chunk;
+        }
+
+        if (g_progress_callback_func) { 
+            // we indicate progress as number of models written, with an extra progress value for ending write
+            g_progress_callback_func(1.0f,g_progress_callback_user_data); // we ignore the return as exiting here anyway
         }
 
         return buffer_data;


### PR DESCRIPTION
This PR adds a progress callback with implementation in ogt_vox_write_scene and ogt_vox_read_scene*.

The current implementation works well for my own test cases in Avoyd. The ogt_vox_read_scene implementation could be improved slightly by adding more steps to the post processing after file reading but this did not take sufficient time to be visible in my testing.