### PR TITLE
ogt_vox:  added check for buffer and chunk size overflow

### DIFF
--- a/src/ogt_vox.h
+++ b/src/ogt_vox.h
@@ -2584,6 +2584,13 @@
             _vox_file_write_uint32_at_offset(fp, offset_of_chunk_header + 4, &chunk_size);
         }
 
+        // check that the buffer is not larger than the maximum file size, return nothing if would overflow
+        if( fp->data.count > UINT32_MAX ||  (fp->data.count - offset_post_main_chunk ) > UINT32_MAX )
+        {
+            *buffer_size = 0;
+            return NULL;  // note: fp will be freed in dtor on exit
+        }
+
         // we deliberately don't free the fp->data field, just pass the buffer pointer and size out to the caller
         *buffer_size = (uint32_t)fp->data.count;
         uint8_t* buffer_data = _vox_file_get_data(fp);

--- a/src/ogt_vox.h
+++ b/src/ogt_vox.h
@@ -2585,7 +2585,7 @@
         }
 
         // check that the buffer is not larger than the maximum file size, return nothing if would overflow
-        if( fp->data.count > UINT32_MAX ||  (fp->data.count - offset_post_main_chunk ) > UINT32_MAX )
+        if (fp->data.count > UINT32_MAX ||  (fp->data.count - offset_post_main_chunk) > UINT32_MAX)
         {
             ogt_assert(0, "Generated file size exceeded 4GiB, which is too large for Magicavoxel to parse.");
             *buffer_size = 0;

--- a/src/ogt_vox.h
+++ b/src/ogt_vox.h
@@ -2587,6 +2587,7 @@
         // check that the buffer is not larger than the maximum file size, return nothing if would overflow
         if( fp->data.count > UINT32_MAX ||  (fp->data.count - offset_post_main_chunk ) > UINT32_MAX )
         {
+            ogt_assert(0, "Generated file size exceeded 4GiB, which is too large for Magicavoxel to parse.");
             *buffer_size = 0;
             return NULL;  // note: fp will be freed in dtor on exit
         }


### PR DESCRIPTION
This PR adds a check for potential buffer_size  and chunk size overflow, exiting and returning NULL if this would occur.

This prevents a corrupt .vox file from being generated, which is possible even within the MagicaVoxel 2kx1kx2k visible scene limitations.