### PR TITLE
CI: added windows and osx builds as well as tests to the github pipelines

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,10 @@ jobs:
             cmake --build . --config Release
             cmake --install .  --prefix opengametools-install
 
+        - name: Test
+          run: |
+            ctest -V -C Release .
+
         - name: Upload the build artifacts
           uses: actions/upload-artifact@v3
           with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,15 +11,29 @@ on:
       - master
 
 jobs:
-    linux:
-        runs-on: ubuntu-latest
+    build:
+        runs-on: ${{ matrix.platform.os }}
+        name: ${{ matrix.platform.name }}
 
         steps:
         - uses: actions/checkout@v3
 
-        - name: Linux
+        - name: Build
           run: |
-            g++ -Wall -Wextra -pedantic apps/vox2fbx.cpp
-            g++ -Wall -Wextra -pedantic apps/vox2obj.cpp
-            g++ -Wall -Wextra -pedantic apps/voxmerge.cpp
-            g++ -Wall -Wextra -pedantic apps/voxseparate.cpp
+            cmake .
+            cmake --build . --config Release
+            cmake --install .  --prefix opengametools-install
+
+        - name: Upload the build artifacts
+          uses: actions/upload-artifact@v3
+          with:
+            name: opengametools-${{ matrix.platform.name }}
+            path: opengametools-install
+
+        strategy:
+          fail-fast: false
+          matrix:
+            platform:
+            - { name: Windows,  os: windows-2022 }
+            - { name: Ubuntu,   os: ubuntu-latest }
+            - { name: MacOS,    os: macos-latest }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/vox2fbx
+/vox2obj
+/voxmerge
+/voxseparate
+/build
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,22 @@
 project(opengametools CXX)
 
 set(APPS
-    vox2fbx
-    vox2obj
-    voxmerge
-    voxseparate
+    apps/vox2fbx.cpp
+    apps/vox2obj.cpp
+    apps/voxmerge.cpp
+    apps/voxseparate.cpp
+    demo/demo_vox.cpp
 )
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 foreach (app ${APPS})
-    add_executable(${app} apps/${app}.cpp)
-    target_compile_options(${app} PRIVATE
+    get_filename_component(APP_NAME ${app} NAME_WE) 
+    add_executable(${APP_NAME} ${app})
+    target_compile_options(${APP_NAME} PRIVATE
         $<$<CXX_COMPILER_ID:MSVC>:/W4>
         $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra -Wpedantic>
     )
-    install(TARGETS ${app} DESTINATION bin)
+    install(TARGETS ${APP_NAME} DESTINATION bin)
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,3 +20,6 @@ foreach (app ${APPS})
     )
     install(TARGETS ${APP_NAME} DESTINATION bin)
 endforeach()
+
+include(CTest)
+add_test(NAME test_multiple_model_scene COMMAND $<TARGET_FILE:demo_vox> ${CMAKE_CURRENT_SOURCE_DIR}/demo/vox/test_multiple_model_scene.vox)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+project(opengametools CXX)
+
+set(APPS
+    vox2fbx
+    vox2obj
+    voxmerge
+    voxseparate
+)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+
+foreach (app ${APPS})
+    add_executable(${app} apps/${app}.cpp)
+    target_compile_options(${app} PRIVATE
+        $<$<CXX_COMPILER_ID:MSVC>:/W4>
+        $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra -Wpedantic>
+    )
+    install(TARGETS ${app} DESTINATION bin)
+endforeach()

--- a/demo/demo_vox.cpp
+++ b/demo/demo_vox.cpp
@@ -101,9 +101,9 @@ uint32_t count_solid_voxels_in_model(const ogt_vox_model* model)
     return solid_voxel_count;
 }
 
-void demo_load_and_save()
+bool demo_load_and_save(const char *filename)
 {
-    const ogt_vox_scene* scene = load_vox_scene_with_groups("vox/test_groups.vox");
+    const ogt_vox_scene* scene = load_vox_scene_with_groups(filename);
     if (scene)
     {
         printf("#layers: %u\n", scene->num_layers);
@@ -170,7 +170,10 @@ void demo_load_and_save()
         save_vox_scene("saved.vox", scene); 
 
         ogt_vox_destroy_scene(scene);
+        return true;
     }
+    fprintf(stderr, "Failed to load %s\n", filename);
+    return false;
 }
 
 // demonstrates merging multiple scenes together
@@ -216,8 +219,17 @@ void demo_merge_scenes()
 
 int main(int argc, char** argv)
 {
-    demo_load_and_save();
+    const char *filename = "vox/test_groups.vox";
+    if (argc == 2)
+    {
+        filename = argv[1];
+    }
+    if (!demo_load_and_save(filename))
+    {
+        return 1;
+    }
     demo_merge_scenes();
+    return 0;
 }
 
 /* -------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/ogt_vox.h
+++ b/src/ogt_vox.h
@@ -206,6 +206,9 @@
     #include <inttypes.h>
 #elif __APPLE__
     // general Apple compiler
+    #include <stdint.h>
+    #include <limits.h>
+    #include <stdlib.h> // for size_t
 #elif defined(__GNUC__)
     // any GCC*
     #include <inttypes.h>


### PR DESCRIPTION
I've added a very basic cmake script to perform the cl.exe search - I'm not very familiar with windows and could find an easy way to find cl.exe.

I've also added a test case in form of the demo_vox application to the pipeline.

The build artifacts are attached to each pipeline run.

see https://github.com/jpaver/opengametools/actions/runs/5637436975