### PR TITLE
CHUNK_ID_XYZI voxel bounds check to improve handling of corrupt files

### DIFF
--- a/src/ogt_vox.h
+++ b/src/ogt_vox.h
@@ -1399,7 +1399,9 @@
                             uint8_t z = packed_voxel_data[i * 4 + 2];
                             uint8_t color_index = packed_voxel_data[i * 4 + 3];
                             ogt_assert(x < size_x && y < size_y && z < size_z, "invalid data in XYZI chunk");
-                            voxel_data[(x * k_stride_x) + (y * k_stride_y) + (z * k_stride_z)] = color_index;
+                            if(x < size_x && y < size_y && z < size_z ) { 
+                                voxel_data[(x * k_stride_x) + (y * k_stride_y) + (z * k_stride_z)] = color_index;
+                            }
                         }
                         _vox_file_seek_forwards(fp, num_voxels_in_chunk * 4);
                         // compute the hash of the voxels in this model-- used to accelerate duplicate models checking.


### PR DESCRIPTION
I've encountered a number of vox files which were corrupt with voxels outside the bounds of the model size. This results in the voxel array bounds being overwritten when loaded.

There's already an assert in the code, but this PR adds the same test to adding the voxel data to the array. I've been able to recover some data from models which otherwise would not load with this addition and I don't think the performance hit is significant.