### PR TITLE
ogt_vox: added _ri material support

### DIFF
--- a/src/ogt_vox.h
+++ b/src/ogt_vox.h
@@ -1697,6 +1697,11 @@
                         materials.matl[material_id].content_flags |= k_ogt_vox_matl_have_ior;
                         materials.matl[material_id].ior = (float)atof(ior_string);
                     }
+                    const char* ri_string = _vox_dict_get_value_as_string(&dict, "_ri", NULL);
+                    if (ri_string) {
+                        materials.matl[material_id].content_flags |= k_ogt_vox_matl_have_ior;
+                        materials.matl[material_id].ior = (float)atof(ri_string) - 1.0f;
+                    }
                     const char* att_string = _vox_dict_get_value_as_string(&dict, "_att", NULL);
                     if (att_string) {
                         materials.matl[material_id].content_flags |= k_ogt_vox_matl_have_att;


### PR DESCRIPTION
ior is ri - 1.0 (according to VOX4U (unreal 5 plugin)

some of the found values in existing vox files:

key: _ri, value: 1.01
key: _ri, value: 1.02
key: _ri, value: 1.03
key: _ri, value: 1.04
key: _ri, value: 1.09
key: _ri, value: 1.16
key: _ri, value: 1.2
key: _ri, value: 1.3
key: _ri, value: 1.33
key: _ri, value: 1.48
key: _ri, value: 1.52
key: _ri, value: 1.53
key: _ri, value: 1.66
key: _ri, value: 1.71
key: _ri, value: 1.82
key: _ri, value: 1.94
key: _ri, value: 2
key: _ri, value: 2.17
key: _ri, value: 2.33