### PR TITLE
Correct comment that mistakenly suggests this library works compiled as C

### DIFF
--- a/src/ogt_vox.h
+++ b/src/ogt_vox.h
@@ -15,7 +15,7 @@
 
     HOW TO COMPILE THIS LIBRARY
 
-    1.  To compile this library, do this in *one* C or C++ file:
+    1.  To compile this library, do this in *one* C++ file:
         #define OGT_VOX_IMPLEMENTATION
         #include "ogt_vox.h"
 


### PR DESCRIPTION
This library must be compiled as C++. This comment in the src confused me for a few minutes so thought I'd submit a PR to rectify it.